### PR TITLE
Add in SPDX identifiers in one place.

### DIFF
--- a/manual/apache.json
+++ b/manual/apache.json
@@ -1,12 +1,7 @@
 [
     {
         "id": "Apache-2.0",
-        "identifiers": [
-            {
-                "identifier": "Apache-2.0",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",

--- a/manual/bsd.json
+++ b/manual/bsd.json
@@ -1,12 +1,7 @@
 [
     {
         "id": "BSD-2",
-        "identifiers": [
-            {
-                "identifier": "BSD-2-Clause",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",
@@ -40,12 +35,7 @@
     },
     {
         "id": "BSD-3",
-        "identifiers": [
-            {
-                "identifier": "BSD-3-Clause",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",
@@ -83,12 +73,7 @@
     },
     {
         "id": "BSD-4",
-        "identifiers": [
-            {
-                "identifier": "BSD-4-Clause",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",

--- a/manual/cddl.json
+++ b/manual/cddl.json
@@ -1,12 +1,7 @@
 [
     {
         "id": "CDDL-1.0",
-        "identifiers": [
-            {
-                "identifier": "CDDL-1.0",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",

--- a/manual/epl.json
+++ b/manual/epl.json
@@ -1,12 +1,7 @@
 [
     {
         "id": "EPL-1.0",
-        "identifiers": [
-            {
-                "identifier": "EPL-1.0",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",

--- a/manual/expat.json
+++ b/manual/expat.json
@@ -3,10 +3,6 @@
         "id": "Expat",
         "identifiers": [
             {
-                "identifier": "MIT",
-                "scheme": "SPDX"
-            },
-            {
                 "identifier": "Expat",
                 "scheme": "DEP5"
             }

--- a/manual/gpl.json
+++ b/manual/gpl.json
@@ -1,12 +1,7 @@
 [
     {
         "id": "GPL-3.0",
-        "identifiers": [
-            {
-                "identifier": "GPL-3.0",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",
@@ -36,12 +31,7 @@
     },
     {
         "id": "GPL-2.0",
-        "identifiers": [
-            {
-                "identifier": "GPL-2.0",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",

--- a/manual/lgpl.json
+++ b/manual/lgpl.json
@@ -1,12 +1,7 @@
 [
     {
         "id": "LGPL-3.0",
-        "identifiers": [
-            {
-                "identifier": "LGPL-3.0",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",
@@ -36,12 +31,7 @@
     },
     {
         "id": "LGPL-2.1",
-        "identifiers": [
-            {
-                "identifier": "LGPL-2.1",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",

--- a/manual/mpl.json
+++ b/manual/mpl.json
@@ -1,12 +1,7 @@
 [
     {
         "id": "MPL-2.0",
-        "identifiers": [
-            {
-                "identifier": "MPL-2.0",
-                "scheme": "SPDX"
-            }
-        ],
+        "identifiers": [],
         "links": [
             {
                 "note": "OSI Page",

--- a/spdx/manual.json
+++ b/spdx/manual.json
@@ -1,0 +1,56 @@
+[
+    {
+        "id": "BSD-2",
+        "identifiers": [
+            {
+                "identifier": "BSD-2-Clause",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "BSD-3",
+        "identifiers": [
+            {
+                "identifier": "BSD-3-Clause",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "BSD-4",
+        "identifiers": [
+            {
+                "identifier": "BSD-4-Clause",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Expat",
+        "identifiers": [
+            {
+                "identifier": "MIT",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Simple-2.0",
+        "identifiers": [
+            {
+                "identifier": "SimPL-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "WXwindows",
+        "identifiers": [
+            {
+                "identifier": "WXwindows",
+                "scheme": "SPDX"
+            }
+        ]
+    }
+]

--- a/spdx/scrape.py
+++ b/spdx/scrape.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2015, Paul R. Tagliamonte <paultag@opensource.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import json
+import requests
+import lxml.html
+
+
+def lxmlize(url):
+    page = lxml.html.fromstring(requests.get(url).text)
+    page.make_links_absolute(url)
+    return page
+
+
+def stream(known):
+    for license in lxmlize("http://spdx.org/licenses/").xpath(
+        "//table[@class='sortable']//tbody//tr"
+    ):
+        name, spdx, approved, _ = license.xpath("./td")
+        name, = name.xpath("./a/text()")
+        license_id, = spdx.xpath(".//code[@property='spdx:licenseId']/text()")
+
+        if license_id not in known:
+            sys.stderr.write("Unknown license: {}\n".format(license_id))
+            sys.stderr.flush()
+            continue
+
+        yield {
+            "id": license_id,
+            "identifiers": [
+                {"scheme": "SPDX",
+                 "identifier": license_id},
+            ]
+        }
+
+
+def scrape():
+    known = [x['id'] for x in json.load(open(sys.argv[1]))]
+    json.dump(list(stream(known)), sys.stdout, sort_keys=True, indent=4)
+
+scrape()

--- a/spdx/spdx.json
+++ b/spdx/spdx.json
@@ -1,0 +1,686 @@
+[
+    {
+        "id": "AFL-3.0",
+        "identifiers": [
+            {
+                "identifier": "AFL-3.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "APL-1.0",
+        "identifiers": [
+            {
+                "identifier": "APL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Apache-1.1",
+        "identifiers": [
+            {
+                "identifier": "Apache-1.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Apache-2.0",
+        "identifiers": [
+            {
+                "identifier": "Apache-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "APSL-2.0",
+        "identifiers": [
+            {
+                "identifier": "APSL-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Artistic-1.0",
+        "identifiers": [
+            {
+                "identifier": "Artistic-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Artistic-2.0",
+        "identifiers": [
+            {
+                "identifier": "Artistic-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "AAL",
+        "identifiers": [
+            {
+                "identifier": "AAL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "BSL-1.0",
+        "identifiers": [
+            {
+                "identifier": "BSL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "CNRI-Python",
+        "identifiers": [
+            {
+                "identifier": "CNRI-Python",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "CDDL-1.0",
+        "identifiers": [
+            {
+                "identifier": "CDDL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "CPAL-1.0",
+        "identifiers": [
+            {
+                "identifier": "CPAL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "CPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "CPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "CATOSL-1.1",
+        "identifiers": [
+            {
+                "identifier": "CATOSL-1.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "CUA-OPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "CUA-OPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "EPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "EPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "ECL-1.0",
+        "identifiers": [
+            {
+                "identifier": "ECL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "ECL-2.0",
+        "identifiers": [
+            {
+                "identifier": "ECL-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "EFL-1.0",
+        "identifiers": [
+            {
+                "identifier": "EFL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "EFL-2.0",
+        "identifiers": [
+            {
+                "identifier": "EFL-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Entessa",
+        "identifiers": [
+            {
+                "identifier": "Entessa",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "EUDatagrid",
+        "identifiers": [
+            {
+                "identifier": "EUDatagrid",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "EUPL-1.1",
+        "identifiers": [
+            {
+                "identifier": "EUPL-1.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Fair",
+        "identifiers": [
+            {
+                "identifier": "Fair",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Frameworx-1.0",
+        "identifiers": [
+            {
+                "identifier": "Frameworx-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "AGPL-3.0",
+        "identifiers": [
+            {
+                "identifier": "AGPL-3.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "GPL-2.0",
+        "identifiers": [
+            {
+                "identifier": "GPL-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "GPL-3.0",
+        "identifiers": [
+            {
+                "identifier": "GPL-3.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "LGPL-2.1",
+        "identifiers": [
+            {
+                "identifier": "LGPL-2.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "LGPL-3.0",
+        "identifiers": [
+            {
+                "identifier": "LGPL-3.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "HPND",
+        "identifiers": [
+            {
+                "identifier": "HPND",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "IPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "IPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Intel",
+        "identifiers": [
+            {
+                "identifier": "Intel",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "IPA",
+        "identifiers": [
+            {
+                "identifier": "IPA",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "ISC",
+        "identifiers": [
+            {
+                "identifier": "ISC",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "LPPL-1.3c",
+        "identifiers": [
+            {
+                "identifier": "LPPL-1.3c",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "LPL-1.02",
+        "identifiers": [
+            {
+                "identifier": "LPL-1.02",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "LPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "LPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "MS-PL",
+        "identifiers": [
+            {
+                "identifier": "MS-PL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "MS-RL",
+        "identifiers": [
+            {
+                "identifier": "MS-RL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "MirOS",
+        "identifiers": [
+            {
+                "identifier": "MirOS",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Motosoto",
+        "identifiers": [
+            {
+                "identifier": "Motosoto",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "MPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "MPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "MPL-1.1",
+        "identifiers": [
+            {
+                "identifier": "MPL-1.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "MPL-2.0",
+        "identifiers": [
+            {
+                "identifier": "MPL-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Multics",
+        "identifiers": [
+            {
+                "identifier": "Multics",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "NASA-1.3",
+        "identifiers": [
+            {
+                "identifier": "NASA-1.3",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Naumen",
+        "identifiers": [
+            {
+                "identifier": "Naumen",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "NGPL",
+        "identifiers": [
+            {
+                "identifier": "NGPL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Nokia",
+        "identifiers": [
+            {
+                "identifier": "Nokia",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "NPOSL-3.0",
+        "identifiers": [
+            {
+                "identifier": "NPOSL-3.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "NTP",
+        "identifiers": [
+            {
+                "identifier": "NTP",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "OCLC-2.0",
+        "identifiers": [
+            {
+                "identifier": "OCLC-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "OGTSL",
+        "identifiers": [
+            {
+                "identifier": "OGTSL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "OSL-1.0",
+        "identifiers": [
+            {
+                "identifier": "OSL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "OSL-2.1",
+        "identifiers": [
+            {
+                "identifier": "OSL-2.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "OSL-3.0",
+        "identifiers": [
+            {
+                "identifier": "OSL-3.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "PHP-3.0",
+        "identifiers": [
+            {
+                "identifier": "PHP-3.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "PostgreSQL",
+        "identifiers": [
+            {
+                "identifier": "PostgreSQL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Python-2.0",
+        "identifiers": [
+            {
+                "identifier": "Python-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "QPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "QPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "RPSL-1.0",
+        "identifiers": [
+            {
+                "identifier": "RPSL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "RPL-1.1",
+        "identifiers": [
+            {
+                "identifier": "RPL-1.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "RPL-1.5",
+        "identifiers": [
+            {
+                "identifier": "RPL-1.5",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "RSCPL",
+        "identifiers": [
+            {
+                "identifier": "RSCPL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "OFL-1.1",
+        "identifiers": [
+            {
+                "identifier": "OFL-1.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Sleepycat",
+        "identifiers": [
+            {
+                "identifier": "Sleepycat",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "SISSL",
+        "identifiers": [
+            {
+                "identifier": "SISSL",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "SPL-1.0",
+        "identifiers": [
+            {
+                "identifier": "SPL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Watcom-1.0",
+        "identifiers": [
+            {
+                "identifier": "Watcom-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "NCSA",
+        "identifiers": [
+            {
+                "identifier": "NCSA",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "VSL-1.0",
+        "identifiers": [
+            {
+                "identifier": "VSL-1.0",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "W3C",
+        "identifiers": [
+            {
+                "identifier": "W3C",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Xnet",
+        "identifiers": [
+            {
+                "identifier": "Xnet",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "Zlib",
+        "identifiers": [
+            {
+                "identifier": "Zlib",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "ZPL-2.0",
+        "identifiers": [
+            {
+                "identifier": "ZPL-2.0",
+                "scheme": "SPDX"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
 This refactors out the Identifiers from the manual collection and punts
 them back out into one place. This only catches ones that have a
 matching identifier.