### PR TITLE
Correct licence name

### DIFF
--- a/licenses/autogenerated/miros.json
+++ b/licenses/autogenerated/miros.json
@@ -7,7 +7,7 @@
                 "url": "https://opensource.org/licenses/MirOS"
             }
         ],
-        "name": "MirOS License (MirOS)",
+        "name": "The MirOS Licence (MirOS)",
         "keywords": [
             "osi-approved"
         ],


### PR DESCRIPTION
Use the formal name of the licence, which is “The MirOS Licence”.