### PR TITLE
fixup MirOS licence body text:

### DIFF
--- a/texts/plain/MirOS
+++ b/texts/plain/MirOS
@@ -1,51 +1,54 @@
+/*-
+ * Copyright (c) year, year, year, ...
+ *	First M. Last <user@host.domain>
+ *
+ * Provided that these terms and disclaimer and all copyright notices
+ * are retained or reproduced in an accompanying document, permission
+ * is granted to deal in this work without restriction, including un-
+ * limited rights to use, publicly perform, distribute, sell, modify,
+ * merge, give away, or sublicence.
+ *
+ * This work is provided "AS IS" and WITHOUT WARRANTY of any kind, to
+ * the utmost extent permitted by applicable law, neither express nor
+ * implied; without malicious intent or gross negligence. In no event
+ * may a licensor, author or contributor be held liable for indirect,
+ * direct, other damage, loss, or other issues arising in any way out
+ * of dealing in the work, even if advised of the possibility of such
+ * damage or existence of a defect, except proven that it results out
+ * of said person's immediate fault when using the work as intended.
+ */
 
-        /*-
-     * Copyright © year, year, year, …
-     * First M. Last <user@host.domain>
-     *
-     * Provided that these terms and disclaimer and all copyright notices
-     * are retained or reproduced in an accompanying document, permission
-     * is granted to deal in this work without restriction, including un‐
-     * limited rights to use, publicly perform, distribute, sell, modify,
-     * merge, give away, or sublicence.
-     *
-     * This work is provided "AS IS" and WITHOUT WARRANTY of any kind, to
-     * the utmost extent permitted by applicable law, neither express nor
-     * implied; without malicious intent or gross negligence. In no event
-     * may a licensor, author or contributor be held liable for indirect,
-     * direct, other damage, loss, or other issues arising in any way out
-     * of dealing in the work, even if advised of the possibility of such
-     * damage or existence of a defect, except proven that it results out
-     * of said person's immediate fault when using the work as intended.
-     */
-     I_N_S_T_R_U_C_T_I_O_N_S_:_
-     To apply the template(¹) specify the years of copyright (separated by
-     comma, not as a range), the legal names of the copyright holders, and
-     the real names of the authors if different. Avoid adding text.
-     R_A_T_I_O_N_A_L_E_:_
-     This licence is apt for any kind of work (such as source code, fonts,
-     documentation, graphics, sound etc.) and the preferred terms for work
-     added to MirBSD. It has been drafted as universally usable equivalent
-     of the "historic permission notice"⁽²⁾ adapted to Europen law because
-     in some (droit d'auteur) countries authors cannot disclaim all liabi‐
-     lities. Compliance to DFSG⁽³⁾ 1.1 is ensured, and GPLv2 compatibility
-     is asserted unless advertising clauses are used. The MirOS Licence is
-     certified to conform to OKD⁽⁴⁾ 1.0 and OSD⁽⁵⁾ 1.9, and qualifies as a
-     Free Software⁽⁶⁾ and also Free Documentation⁽⁷⁾ licence and is inclu‐
-     ded in some relevant lists⁽⁸⁾⁽⁹⁾⁽¹⁰⁾.
-     We believe you are not liable for work inserted which is intellectual
-     property of third parties, if you were not aware of the fact, act ap‐
-     propriately as soon as you become aware of that problem, seek an ami‐
-     cable solution for all parties, and never knowingly distribute a work
-     without being authorised to do so by its licensors.
-     R_E_F_E_R_E_N_C_E_S_:_
-     ① also at http://mirbsd.de/MirOS-Licence
-     ② http://www.opensource.org/licenses/historical.php
-     ③ http://www.debian.org/social_contract#guidelines
-     ④ http://www.opendefinition.org/1.0
-     ⑤ http://www.opensource.org/docs/osd
-     ⑥ http://www.gnu.org/philosophy/free-sw.html
-     ⑦ http://www.gnu.org/philosophy/free-doc.html
-     ⑧ http://www.ifross.de/ifross_html/lizenzcenter.html
-     ⑨ http://www.opendefinition.org/licenses
-     ⑩ http://opensource.org/licenses/miros.html  
+INSTRUCTIONS:
+To apply the template[1] specify the years of copyright (separated by
+comma, not as a range), the legal names of the copyright holders, and
+the real names of the authors if different. Avoid adding text.
+
+RATIONALE:
+This licence is apt for any kind of work (such as source code, fonts,
+documentation, graphics, sound etc.) and the preferred terms for work
+added to MirBSD. It has been drafted as universally usable equivalent
+of the "historic permission notice"[2] adapted to Europen law because
+in some (droit d'auteur) countries authors cannot disclaim all liabi-
+lities. Compliance to DFSG[3] 1.1 is ensured, and GPLv2 compatibility
+is asserted unless advertising clauses are used. The MirOS Licence is
+certified to conform to OKD[4] 1.0 and OSD[5] 1.9, and qualifies as a
+Free Software[6] and also Free Documentation[7] licence and is inclu-
+ded in some relevant lists[8][9][10][11].
+
+REFERENCES:
+[1] also (as ASCII version) at http://mirbsd.de/MirOS-Licence.asc and (in
+    UTF-8) at https://www.mirbsd.org/MirOS-Licence and (HTML, with an in-
+    official German translation) https://www.mirbsd.org/MirOS-Licence.htm
+[2] http://www.opensource.org/licenses/historical.php
+[3] http://www.debian.org/social_contract#guidelines
+[4] http://www.opendefinition.org/1.0
+[5] http://www.opensource.org/docs/osd
+[6] http://www.gnu.org/philosophy/free-sw.html
+[7] http://www.gnu.org/philosophy/free-doc.html
+[8] http://www.ifross.de/ifross_html/lizenzcenter.html
+[9] http://www.opendefinition.org/licenses
+[10] http://opensource.org/licenses/miros.html
+[11] http://copyfree.org/licenses/
+
+___________________________________________________________________________
+$MirOS: src/share/misc/licence.template,v 1.30 2016/03/25 20:13:23 tg Rel $


### PR DESCRIPTION
• switch to ASCII version, as the OSI editor seems to have problems
  with my fancy UTF-8 (and seems to ignore my repeat requests to fix the text)
• update from MirBSD master
  – project-level discussion is now separate from licence-level info
    (and thus not needed to be included on the OSI page)
  – added link to German translation
  – another reference added