### PR TITLE
Remove BSD-4. This appears to not be OSI approved

### DIFF
--- a/licenses/dep5/dep5.json
+++ b/licenses/dep5/dep5.json
@@ -45,15 +45,6 @@
         ]
     },
     {
-        "id": "BSD-4",
-        "identifiers": [
-            {
-                "identifier": "BSD-4-clause",
-                "scheme": "DEP5"
-            }
-        ]
-    },
-    {
         "id": "ISC",
         "identifiers": [
             {

--- a/licenses/manual/bsd.json
+++ b/licenses/manual/bsd.json
@@ -70,34 +70,5 @@
                 "url": "https://opensource.org/licenses/BSD-3-Clause"
             }
         ]
-    },
-    {
-        "id": "BSD-4",
-        "identifiers": [],
-        "keywords": [
-            "osi-approved",
-            "permissive"
-        ],
-        "links": [
-            {
-                "note": "OSI Page",
-                "url": "https://opensource.org/licenses/BSD-4-Clause"
-            }
-        ],
-        "name": "BSD 4-Clause License",
-        "other_names": [
-            {
-                "name": "Original BSD License",
-                "note": null
-            }
-        ],
-        "superseded_by": null,
-        "text": [
-            {
-                "media_type": "text/html",
-                "title": "HTML",
-                "url": "https://opensource.org/licenses/BSD-4-Clause"
-            }
-        ]
     }
 ]

--- a/licenses/spdx/manual.json
+++ b/licenses/spdx/manual.json
@@ -18,15 +18,6 @@
         ]
     },
     {
-        "id": "BSD-4",
-        "identifiers": [
-            {
-                "identifier": "BSD-4-Clause",
-                "scheme": "SPDX"
-            }
-        ]
-    },
-    {
         "id": "MIT",
         "identifiers": [
             {

--- a/licenses/wikipedia/wikipedia.json
+++ b/licenses/wikipedia/wikipedia.json
@@ -225,15 +225,6 @@
         "links": []
     },
     {
-        "id": "BSD-4",
-        "links": [
-            {
-                "note": "Wikipedia Page",
-                "url": "https://en.wikipedia.org/wiki/BSD_licenses#4-clause"
-            }
-        ]
-    },
-    {
         "id": "EUPL-1.1",
         "links": []
     },


### PR DESCRIPTION
I think this is due to me creating test data for the API
in the early days, and should have never been commited.