### PR TITLE
Add BSDplusPatent license (SPDX ID BSD-2-Clause-Patent)

### DIFF
--- a/licenses/manual/BSDplusPatent.json
+++ b/licenses/manual/BSDplusPatent.json
@@ -1,0 +1,27 @@
+[
+    {
+        "id": "BSDplusPatent",
+        "identifiers": [],
+        "keywords": [
+            "osi-approved"
+        ],
+        "links": [
+            {
+                "note": "OSI Page",
+                "url": "https://opensource.org/licenses/BSDplusPatent"
+            },
+            {
+                "note": "SPDX page",
+                "url": "https://spdx.org/licenses/BSD-2-Clause-Patent"
+            }
+        ],
+        "name": "BSD-2-Clause Plus Patent License",
+        "text": [
+            {
+                "media_type": "text/html",
+                "title": "HTML",
+                "url": "https://opensource.org/licenses/BSDplusPatent"
+            }
+        ]
+    }
+]

--- a/licenses/manual/BSDplusPatent.json
+++ b/licenses/manual/BSDplusPatent.json
@@ -15,7 +15,7 @@
                 "url": "https://spdx.org/licenses/BSD-2-Clause-Patent"
             }
         ],
-        "name": "BSD-2-Clause Plus Patent License",
+        "name": "BSD+Patent",
         "text": [
             {
                 "media_type": "text/html",

--- a/licenses/spdx/importedSpdxFiles.json
+++ b/licenses/spdx/importedSpdxFiles.json
@@ -1,0 +1,11 @@
+[
+    {
+        "id": "BSDplusPatent",
+        "identifiers": [
+            {
+                "identifier": "BSD-2-Clause-Patent",
+                "scheme": "SPDX"
+            }
+        ]
+    }
+]

--- a/texts/plain/BSDplusPatent
+++ b/texts/plain/BSDplusPatent
@@ -1,0 +1,19 @@
+Copyright (c) <YEAR> <COPYRIGHT HOLDERS>
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors, in source or binary form) alone; or
+
+(b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
+
+Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this license, whether expressly, by implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Partially resolves issue #62 

Note that the license name was updated to match the OSI website.

License text was an exact match between the OSI and SPDX website.