### PR TITLE
Add missing SPDX IDs for UPL-1.0 and LiLiQ-R+

### DIFF
--- a/licenses/spdx/spdx.json
+++ b/licenses/spdx/spdx.json
@@ -324,6 +324,14 @@
         ]
     },
     {
+        "id": "LiLiQ-R+",
+        "identifiers": [
+            {
+                "identifier": "LiLiQ-Rplus-1.1",
+                "scheme": "SPDX"
+            }
+        ]
+    },    {
         "id": "MIT",
         "identifiers": [
             {
@@ -616,6 +624,15 @@
         "identifiers": [
             {
                 "identifier": "Sleepycat",
+                "scheme": "SPDX"
+            }
+        ]
+    },
+    {
+        "id": "UPL",
+        "identifiers": [
+            {
+                "identifier": "UPL-1.0",
                 "scheme": "SPDX"
             }
         ]


### PR DESCRIPTION
Partially resolves issue #62 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>