### PR TITLE
Repair the script which scrapes license texts from the OSI website

### DIFF
--- a/texts/plain/scrape.py
+++ b/texts/plain/scrape.py
@@ -28,8 +28,10 @@ def lxmlize(url):
 
 
 def do_scrape(id_):
-    text ,= lxmlize("http://opensource.org/licenses/{}".format(id_)).xpath(
-        "//div[@class='content clearfix']"
+    text ,= lxmlize(
+        "https://opensource.org/licenses/{}".format(id_)
+    ).find_class(
+        "entry-content"
     )
     return text.text_content()
 


### PR DESCRIPTION
Since the big changes to the OSI website, the license text scraping script does not work anymore. This pull request contains a commit which repairs it.

I don’t know how exact the script is expected to work; however, if some manual work is expected, the changed script should be a very good start.

See the commit message for details.