### PR TITLE
Use HTTPS instead of HTTP in the SPDX scraping script

### DIFF
--- a/licenses/spdx/scrape.py
+++ b/licenses/spdx/scrape.py
@@ -19,7 +19,7 @@ import json
 import requests
 
 def stream(known):
-    request = requests.get("http://spdx.org/licenses/licenses.json")
+    request = requests.get("https://spdx.org/licenses/licenses.json")
     spdx_json = request.json()
     licenses = sorted(spdx_json["licenses"], key=lambda x: x["licenseId"])
     for license in licenses:


### PR DESCRIPTION
Switch from HTTP to HTTPS when loading the SPDX license data. This saves a redirect and is also good practice.